### PR TITLE
Shipping 생성 로직 Service로 분리 및 Controller 수정

### DIFF
--- a/backend/src/main/java/com/caffe/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/caffe/domain/purchase/service/PurchaseService.java
@@ -97,16 +97,6 @@ public class PurchaseService {
         purchase.addPurchaseItem(purchaseItem);
         purchaseRepository.save(purchase);
 
-        // 배송 담당자 논의 필요
-        // Shipping 저장 -> 해당 서비스의 저장 로직 필요 (매개변수 : Purchase, ReceiverDto)
-        Shipping shipping = new Shipping();
-        shipping.setPurchase(purchase);
-        shipping.setAddress(receiver.address());
-        shipping.setContactNumber(receiver.phoneNumber());
-        shipping.setContactName(receiver.name());
-        shipping.setStatus(ShippingStatus.BEFORE_DELIVERY); // 임시 상태 필요 -> 결제 후 배송전으로 변경
-        shippingRepository.save(shipping);
-
         // 회원 담당자 논의 필요
         // User 저장 - PurchaserReqDto
 

--- a/backend/src/main/java/com/caffe/domain/shipping/controller/ShippingController.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/controller/ShippingController.java
@@ -1,5 +1,6 @@
 package com.caffe.domain.shipping.controller;
 
+import com.caffe.domain.purchase.dto.req.ReceiverReqDto;
 import com.caffe.domain.purchase.entity.Purchase;
 import com.caffe.domain.shipping.dto.ShippingDto;
 import com.caffe.domain.shipping.entity.Shipping;
@@ -22,11 +23,13 @@ public class ShippingController {
       - 프론트에서 받은 ShippingDto를 바탕으로 배송 생성
      */
     @PostMapping
-    public Shipping createShipping(@RequestBody ShippingDto dto) {
-        return shippingService.createShipping(dto);
+    public Shipping createShipping(@RequestParam int purchaseId, @RequestBody ReceiverReqDto receiverReqDto) {
+        Purchase purchase = shippingService.getPurchaseById(purchaseId);
+        return shippingService.createShipping(purchase, receiverReqDto);
     }
 
-    /*
+
+    /*`
       - 최신 구매 내역 조회 API
       - 특정 이메일로 가장 최근에 생성된 구매 내역을 조회
       - 프론트에서 이메일 입력 후 blur 이벤트 시 호출

--- a/backend/src/main/java/com/caffe/domain/shipping/entity/Shipping.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/entity/Shipping.java
@@ -3,7 +3,9 @@ package com.caffe.domain.shipping.entity;
 import com.caffe.domain.purchase.entity.Purchase;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -14,8 +16,8 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@Setter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Shipping {
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -45,4 +47,16 @@ public class Shipping {
     @JoinColumn(name = "purchase_id")
     @JsonBackReference
     private Purchase purchase; // 주문 번호
+
+
+    public Shipping(String address, String contactNumber, String contactName,
+                    String carrier, ShippingStatus status, Purchase purchase) {
+        this.address = address;
+        this.contactNumber = contactNumber;
+        this.contactName = contactName;
+        this.carrier = carrier;
+        this.status = status;
+        this.purchase = purchase;
+        this.createDate = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/caffe/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/service/ShippingService.java
@@ -1,14 +1,15 @@
 package com.caffe.domain.shipping.service;
 
+import com.caffe.domain.purchase.dto.req.ReceiverReqDto;
 import com.caffe.domain.purchase.entity.Purchase;
 import com.caffe.domain.purchase.repository.PurchaseRepository;
-import com.caffe.domain.shipping.dto.ShippingDto;
+import com.caffe.domain.shipping.dto.ReceiverDto;
 import com.caffe.domain.shipping.entity.Shipping;
+import com.caffe.domain.shipping.entity.ShippingStatus;
 import com.caffe.domain.shipping.repository.ShippingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.caffe.domain.shipping.entity.ShippingStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,25 +24,27 @@ public class ShippingService {
 
     /*
      - 배송 정보 생성
-     - 프론트에서 받은 ShippingDto 기반으로 Shipping 엔티티 생성
+     - 매개변수: Purchase, ReceiverDto
      - 배송 상태는 기본적으로 BEFORE_DELIVERY가 설정됨
-     - 이후 저장 후 반환(DELIVERING)
     */
-    public Shipping createShipping(ShippingDto dto) {
-        Purchase purchase = purchaseRepository.findById(dto.getPurchaseId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 구매를 찾을 수 없습니다."));
-
-        Shipping shipping = new Shipping();
-        shipping.setPurchase(purchase);
-        shipping.setAddress(dto.getAddress());
-        shipping.setContactNumber("010-0000-0000"); // TODO: 임시 값, 유저 정보에서 받아오도록 변경 예정
-        shipping.setContactName("홍길동");           // TODO: 임시 값, 유저 정보에서 받아오도록 변경 예정
-        shipping.setCarrier("CJ대한통운");           // TODO: 향후 carrier 선택 기능 있으면 수정
-        shipping.setStatus(dto.getStatus() != null ? dto.getStatus() : ShippingStatus.BEFORE_DELIVERY);
+    public Shipping createShipping(Purchase purchase, ReceiverReqDto receiver) {
+        Shipping shipping = new Shipping(
+                receiver.address(),
+                receiver.phoneNumber(),
+                receiver.name(),
+                "CJ대한통운",  // TODO: carrier 선택 기능 향후 추가
+                ShippingStatus.BEFORE_DELIVERY,
+                purchase
+        );
 
         return shippingRepository.save(shipping);
     }
 
+    // 구매 ID로 Purchase 엔티티를 조회
+    public Purchase getPurchaseById(int purchaseId) {
+        return purchaseRepository.findById(purchaseId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 구매를 찾을 수 없습니다."));
+    }
 
     // 구매 ID로 배송 조회
     public Optional<Shipping> getShippingByPurchaseId(int purchaseId) {


### PR DESCRIPTION
👩‍💻 요구 사항과 구현 내용
- ShippingService에 createShipping(Purchase, ReceiverReqDto) 메서드 추가
- Controller에서 purchaseId와 ReceiverReqDto를 받아 Shipping 생성하도록 수정
- PurchaseService에 있던 Shipping 생성 로직 제거
- 역할을 Controller: 요청 전달 / Service: 생성 및 저장 로직 처리로 분리
