### PR TITLE
구매한 모든 내역으로 배송 생성 및 조회 기능 개선

### DIFF
--- a/backend/src/main/java/com/caffe/domain/purchase/dto/res/ReceiverResDto.java
+++ b/backend/src/main/java/com/caffe/domain/purchase/dto/res/ReceiverResDto.java
@@ -1,7 +1,7 @@
 package com.caffe.domain.purchase.dto.res;
 
 import com.caffe.domain.shipping.entity.Shipping;
-import com.caffe.domain.shipping.entity.ShippingStatus;
+import com.caffe.domain.shipping.constant.ShippingStatus;
 
 public record ReceiverResDto(
         String name,

--- a/backend/src/main/java/com/caffe/domain/purchase/repository/PurchaseRepository.java
+++ b/backend/src/main/java/com/caffe/domain/purchase/repository/PurchaseRepository.java
@@ -3,6 +3,7 @@ package com.caffe.domain.purchase.repository;
 import com.caffe.domain.purchase.entity.Purchase;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Integer> {
@@ -13,6 +14,9 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Integer> {
      - 배송 등록 시 최신 구매에 연결할 때 사용된다.
      */
     Optional<Purchase> findTopByUserEmailOrderByCreateDateDesc(String userEmail);
+
+    // email을 기준으로 그 사람이 구매한 모든 Purchase를 가져올 때 사용
+    List<Purchase> findAllByUserEmail(String userEmail);
 
     // 장바구니 기능 추가 후, 주문:주문 제품 여러개로 될 시 패치조인으로 변경 예정
     Optional<Purchase> findByIdAndUserEmail(int id, String email);

--- a/backend/src/main/java/com/caffe/domain/purchase/service/PurchaseService.java
+++ b/backend/src/main/java/com/caffe/domain/purchase/service/PurchaseService.java
@@ -10,6 +10,7 @@ import com.caffe.domain.purchase.repository.PurchaseItemRepository;
 import com.caffe.domain.purchase.repository.PurchaseRepository;
 import com.caffe.domain.shipping.entity.Shipping;
 import com.caffe.domain.shipping.service.ShippingService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/src/main/java/com/caffe/domain/shipping/constant/ShippingStatus.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/constant/ShippingStatus.java
@@ -1,4 +1,4 @@
-package com.caffe.domain.shipping.entity;
+package com.caffe.domain.shipping.constant;
 
 // 배송 상태를 나타내는 Enum
 public enum ShippingStatus {

--- a/backend/src/main/java/com/caffe/domain/shipping/dto/ShippingDto.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/dto/ShippingDto.java
@@ -1,6 +1,6 @@
 package com.caffe.domain.shipping.dto;
 
-import com.caffe.domain.shipping.entity.ShippingStatus;
+import com.caffe.domain.shipping.constant.ShippingStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,9 +8,10 @@ import lombok.Setter;
 @Setter
 public class ShippingDto {
 
-    private int purchaseId;    // 배송이 연결될 구매(Purchase)의 ID
-    private String address;    // 배송 받을 주소
-    private int postcode;   // 배송지 우편번호
+    private String email;         // 배송지와 연결된 이메일
+    private String address;       // 배송 받을 주소
+    private int postcode;         // 배송지 우편번호
+    private String contactName;   // 수령인 이름
+    private String contactNumber; // 연락처
     private ShippingStatus status;  // 배송 상태 (BEFORE_DELIVERY, DELIVERING, DELIVERED)
-
 }

--- a/backend/src/main/java/com/caffe/domain/shipping/dto/ShippingResDto.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/dto/ShippingResDto.java
@@ -1,5 +1,9 @@
-package com.caffe.domain.shipping.entity;
+package com.caffe.domain.shipping.dto;
 
+import com.caffe.domain.shipping.entity.Shipping;
+import lombok.Getter;
+
+@Getter
 public class ShippingResDto {
 
     private int id;
@@ -13,7 +17,7 @@ public class ShippingResDto {
     public ShippingResDto(Shipping shipping) {
         this.id = shipping.getId();
         this.address = shipping.getAddress();
-        this.postcode = shipping.getPostcode(); // Shipping 엔티티에 postcode 필드 있어야 함
+        this.postcode = shipping.getPostcode();
         this.contactName = shipping.getContactName();
         this.contactNumber = shipping.getContactNumber();
         this.carrier = shipping.getCarrier();

--- a/backend/src/main/java/com/caffe/domain/shipping/entity/Shipping.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/entity/Shipping.java
@@ -1,64 +1,45 @@
 package com.caffe.domain.shipping.entity;
 
 import com.caffe.domain.purchase.entity.Purchase;
-import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.caffe.domain.shipping.constant.ShippingStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Shipping {
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    private int id; // 배송 번호
+    private int id;
 
-    private String address; // 주소
+    private String email;         // 이메일
+    private String address;       // 주소
+    private int postcode;         // 우편번호
+    private String contactName;   // 이름
     private String contactNumber; // 연락처
-    private String contactName; // 이름
-    private String carrier; // 업체
-    private int postcode; // 우편번호
-
+    private String carrier;       // 택배사
 
     @Enumerated(EnumType.STRING)
-    private ShippingStatus status;
+    private ShippingStatus status; // 배송 상태
 
     @CreatedDate
-    private LocalDateTime createDate; // 등록 날짜
+    private LocalDateTime createDate;
 
     @LastModifiedDate
-    private LocalDateTime modifyDate; // 상태 업데이트 날짜
+    private LocalDateTime modifyDate;
 
-    /*
-     - Purchase와 다대일(N:1) 관계
-     - 하나의 Purchase에 여러 배송이 연결될 수 있음
-     - @JsonBackReference: 직렬화 시 순환참조 방지 (JSON 변환 시 Purchase는 직렬화 X)
-     */
+    // purchase 연결 필드 (현재 null 사용중)
     @ManyToOne
     @JoinColumn(name = "purchase_id")
-    @JsonBackReference
-    private Purchase purchase; // 주문 번호
-
-
-    public Shipping(String address, int postcode, String contactNumber, String contactName,
-                    String carrier, ShippingStatus status, Purchase purchase) {
-        this.address = address;
-        this.postcode = postcode;
-        this.contactNumber = contactNumber;
-        this.contactName = contactName;
-        this.carrier = carrier;
-        this.status = status;
-        this.purchase = purchase;
-        this.createDate = LocalDateTime.now();
-    }
+    private Purchase purchase;
 }

--- a/backend/src/main/java/com/caffe/domain/shipping/repository/ShippingRepository.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/repository/ShippingRepository.java
@@ -14,4 +14,6 @@ public interface ShippingRepository extends JpaRepository<Shipping, Integer> {
 
     // 이 이메일 가진 사람이 시킨 배송 목록 가져오기
     List<Shipping> findByPurchaseUserEmail(String userEmail);
+
+    List<Shipping> findByEmail(String email);
 }

--- a/backend/src/main/java/com/caffe/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/caffe/domain/shipping/service/ShippingService.java
@@ -4,7 +4,7 @@ import com.caffe.domain.purchase.dto.req.ReceiverReqDto;
 import com.caffe.domain.purchase.entity.Purchase;
 import com.caffe.domain.purchase.repository.PurchaseRepository;
 import com.caffe.domain.shipping.entity.Shipping;
-import com.caffe.domain.shipping.entity.ShippingStatus;
+import com.caffe.domain.shipping.constant.ShippingStatus;
 import com.caffe.domain.shipping.repository.ShippingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,27 +21,27 @@ public class ShippingService {
     private final ShippingRepository shippingRepository;
     private final PurchaseRepository purchaseRepository;
 
-    /*
-     - 배송 정보 생성
-     - 매개변수: Purchase, ReceiverDto
-     - 배송 상태는 기본적으로 BEFORE_DELIVERY가 설정됨
-    */
+    // 배송 생성 (ReceiverReqDto 기반)
     public Shipping createShipping(ReceiverReqDto receiver, Purchase purchase) {
-        Shipping shipping = new Shipping(
-                receiver.address(),
-                receiver.postcode(),
-                receiver.phoneNumber(),
-                receiver.name(),
-                "CJ대한통운", // TODO: carrier 선택 기능 향후 추가
-                ShippingStatus.TEMPORARY,
-                purchase
-        );
+        Shipping shipping = Shipping.builder()
+                .address(receiver.address())
+                .postcode(receiver.postcode())
+                .contactNumber(receiver.phoneNumber())
+                .contactName(receiver.name())
+                .carrier("CJ대한통운")
+                .status(ShippingStatus.TEMPORARY)
+                .purchase(purchase)
+                .build();
 
         return shippingRepository.save(shipping);
     }
 
 
-    // 구매 ID로 Purchase 엔티티를 조회
+    public Shipping saveShipping(Shipping shipping) {
+        return shippingRepository.save(shipping);
+    }
+
+    // 구매 ID로 구매 조회
     public Purchase getPurchaseById(int purchaseId) {
         return purchaseRepository.findById(purchaseId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 구매를 찾을 수 없습니다."));
@@ -52,8 +52,14 @@ public class ShippingService {
         return shippingRepository.findByPurchaseId(purchaseId);
     }
 
-    // 유저 이메일로 배송 목록 조회
-    public List<Shipping> getShippingListByUserEmail(String userEmail) {
-        return shippingRepository.findByPurchaseUserEmail(userEmail);
+   // 유저 이메일로 배송 목록 조회
+   public List<Shipping> getShippingListByUserEmail(String email) {
+       return shippingRepository.findByEmail(email);
+   }
+
+
+    // 유저 이메일로 구매 내역 조회
+    public List<Purchase> getPurchasesByUserEmail(String userEmail) {
+        return purchaseRepository.findAllByUserEmail(userEmail);
     }
 }

--- a/backend/src/main/resources/templates/sample.html
+++ b/backend/src/main/resources/templates/sample.html
@@ -168,43 +168,45 @@
 <script>
 
   // 선택된 구매 ID
-  let selectedPurchaseId = null;
+let selectedPurchaseId = null;
 
-  // 다음 주소 API를 실행하여 우편번호와 주소를 입력받는 함수
-  function execDaumPostcode() {
-      new daum.Postcode({
-          oncomplete: function(data) {
-              let fullAddr = data.roadAddress ? data.roadAddress : data.jibunAddress;
-              if (data.userSelectedType === 'R') {
-                  let extraAddr = '';
-                  if (data.bname) extraAddr += data.bname;
-                  if (data.buildingName) extraAddr += (extraAddr ? ', ' + data.buildingName : data.buildingName);
-                  if (extraAddr) fullAddr += ' (' + extraAddr + ')';
-              }
-              document.getElementById('postcode').value = data.zonecode;
-              document.getElementById('address').value = fullAddr;
-          }
-      }).open();
-  }
+// 다음 주소 API를 실행하여 우편번호와 주소를 입력받는 함수
+function execDaumPostcode() {
+    new daum.Postcode({
+        oncomplete: function(data) {
+            let fullAddr = data.roadAddress ? data.roadAddress : data.jibunAddress;
+            if (data.userSelectedType === 'R') {
+                let extraAddr = '';
+                if (data.bname) extraAddr += data.bname;
+                if (data.buildingName) extraAddr += (extraAddr ? ', ' + data.buildingName : data.buildingName);
+                if (extraAddr) fullAddr += ' (' + extraAddr + ')';
+            }
+            document.getElementById('postcode').value = data.zonecode;
+            document.getElementById('address').value = fullAddr;
+        }
+    }).open();
+}
 
- // 이메일 입력창에서 포커스가 빠져나갈 때(blur 이벤트 발생)
- document.getElementById('email').addEventListener('blur', () => {
+// 이메일 입력창에서 포커스 아웃
+document.getElementById('email').addEventListener('blur', () => {
     const email = document.getElementById('email').value;
-    if (!email) return; // 이메일이 없으면 종료
+    if (!email) return;
 
-    // 서버에 최신 구매 내역 요청 (이메일로)
-    fetch(`/api/shippings/latest-purchase/${email}`)
-        .then(response => response.json())
-        .then(purchase => {
-
-            // 받아온 구매 정보의 id를 selectedPurchaseId에 저장
-            selectedPurchaseId = purchase.id;
+    fetch(`/api/shippings/purchases/${email}`)
+    .then(response => response.json())
+    .then(purchases => {
+        if (purchases.length > 0) {
+            selectedPurchaseId = purchases[0].id;
             console.log("최신 구매 ID:", selectedPurchaseId);
-        });
-  });
+        } else {
+            alert("구매 내역이 없습니다.");
+        }
+    })
+    .catch(error => console.error('구매 내역 조회 중 오류 발생:', error));
+});
 
-  // 결제하기 버튼 클릭 이벤트
- document.querySelector('.btn-dark').addEventListener('click', () => {
+// 결제 버튼 클릭
+document.querySelector('.btn-dark').addEventListener('click', () => {
     const email = document.getElementById('email').value.trim();
     const name = document.getElementById('name').value.trim();
     const phoneNumber = document.getElementById('phoneNumber').value.trim();
@@ -223,10 +225,15 @@
         return;
     }
 
-    // 연락처 형식 검사
     const phoneRegex = /^010-\d{4}-\d{4}$/;
     if (!phoneRegex.test(phoneNumber)) {
         showInfoModal("연락처는 010-xxxx-yyyy 형식으로 입력해주세요.");
+        return;
+    }
+
+    // selectedPurchaseId가 null이면 차단
+    if (selectedPurchaseId === null) {
+        showInfoModal("구매 내역이 없습니다. 이메일을 다시 확인해주세요.");
         return;
     }
 
@@ -235,37 +242,31 @@
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
             email: email,
-            name: name,
-            phoneNumber: phoneNumber,
+            contactName: name,
+            contactNumber: phoneNumber,
             address: address,
             postcode: postcode,
             status: 'DELIVERING'
         })
     })
-    .then(response => {
-        if (response.ok) {
-            showInfoModal('배송지가 저장되었습니다!');
-            return response.json();
-        } else {
-            showInfoModal('배송 저장 실패!!');
-        }
+    .then(response => response.json())
+    .then(shippings => {
+        console.log("배송이 생성된 목록:", shippings);
+        showInfoModal('결제가 완료되었습니다!');
     })
     .catch(error => {
-        console.error('배송 저장 중 에러 발생:', error);
-        showInfoModal('배송 저장 중 오류가 발생했습니다.');
+        console.error('배송 생성 중 오류 발생:', error);
+        showInfoModal('결제를 실패했습니다.');
     });
 });
 
-
-
-
-
-  // 안내 메시지를 모달로 보여주는 함수
-  function showInfoModal(message) {
+// 모달 표시 함수
+function showInfoModal(message) {
     document.getElementById('infoModalMessage').textContent = message;
     let modal = new bootstrap.Modal(document.getElementById('infoModal'));
     modal.show();
-  }
+}
+
 
 </script>
 


### PR DESCRIPTION
👩‍💻 요구 사항과 구현 내용
- 구매한 모든 내역을 바탕으로 다중 배송 생성 API 추가 (ShippingController)
- 이메일로 배송 목록 조회 시 배송 여러건 반환하도록 기능 보완
- PurchaseRepository에 findAllByUserEmail 메소드 추가
- Shipping Entity 및 Service에 Builder 적용, 필드 정리
- 결제 시 배송 여러건 생성되도록 API 호출 수정
